### PR TITLE
Fix bouyancy engine measurement

### DIFF
--- a/frl_vehicle_msgs/msg/UwGliderStatus.msg
+++ b/frl_vehicle_msgs/msg/UwGliderStatus.msg
@@ -35,5 +35,5 @@ float32 rudder_angle
 # Estiamted battery pack position in m.
 float32 battery_position
 
-# Estimated bouyancy engine pumped volume in L. Positive goes up.
+# Estimated bouyancy engine pumped volume in cm^3. Zero is neutrally buoyant, positive causes the glider to ascend.
 float32 pumped_volume

--- a/frl_vehicle_msgs/msg/UwGliderStatus.msg
+++ b/frl_vehicle_msgs/msg/UwGliderStatus.msg
@@ -35,5 +35,5 @@ float32 rudder_angle
 # Estiamted battery pack position in m.
 float32 battery_position
 
-# Estiamted ballast tank pump position in m.
-float32 ballast_position
+# Estimated bouyancy engine pumped volume in L. Positive goes up.
+float32 pumped_volume


### PR DESCRIPTION
The "ballast_position" should actually be a volumetric measurement of how much
fluid the buoyancy engine has pumped. I chose L as the units because that seems
to fit in with ROS standards, but cubic centimeters is another fine option as
that is what the glider itself reports.

----

#