### PR TITLE
Fix rudder fields

### DIFF
--- a/frl_vehicle_msgs/msg/UwGliderCommand.msg
+++ b/frl_vehicle_msgs/msg/UwGliderCommand.msg
@@ -41,7 +41,7 @@ uint8 RUDDER_ANGLE_PORT=1
 uint8 RUDDER_ANGLE_STBD=2
 uint8 RUDDER_ANGLE_DIRECT=3
 
-# Command: target rudder angle in radians, NED
+# Command: target rudder angle in radians. Positive turns to starboard.
 # Only pertinent if rudder_angle==RUDDER_ANGLE_DIRECT
 float32 target_rudder_angle
 

--- a/frl_vehicle_msgs/msg/UwGliderStatus.msg
+++ b/frl_vehicle_msgs/msg/UwGliderStatus.msg
@@ -29,7 +29,7 @@ float32 altitude
 # Estimated thruster power consumption in Watts
 float32 motor_power
 
-# Estiamted rudder angle in degrees, NED
+# Estimated rudder angle in radians. Positive turns to starboard.
 float32 rudder_angle
 
 # Estiamted battery pack position in m.


### PR DESCRIPTION
Make the units consistent between the Command and Status. NED seemed a little
confusing to describe the directionality, so explicitly state positive turns the
vehicle to starboard (which is what the real hardware does).