### PR TITLE
Document the out of range value for the altimeter

### DIFF
--- a/frl_vehicle_msgs/msg/UwGliderStatus.msg
+++ b/frl_vehicle_msgs/msg/UwGliderStatus.msg
@@ -23,7 +23,7 @@ float32 heading
 # Estimated depth in m.  Positive is down.
 float32 depth
 
-# Estiamted altitude in m.  Positive is up
+# Estimated altitude in m. Positive is up, -1 represents out of range.
 float32 altitude
 
 # Estimated thruster power consumption in Watts


### PR DESCRIPTION
The altimeter has a limited range, so specify what the Status message should
contain when the seafloor is out of range.