### PR TITLE
Better match pitch and ascent/descent controls with actual vehicle

### DIFF
--- a/frl_vehicle_msgs/msg/UwGliderCommand.msg
+++ b/frl_vehicle_msgs/msg/UwGliderCommand.msg
@@ -51,7 +51,7 @@ uint8 RUDDER_ANGLE_DIRECT=3
 # Only pertinent if rudder_angle==RUDDER_ANGLE_DIRECT
 float32 target_rudder_angle
 
-# Command: buoyancy engine pumped volume in L. Positive goes up.
+# Command: buoyancy engine pumped volume in cm^3. Zero is neutrally buoyant, positive causes the glider to ascend.
 float32 target_pumped_volume
 
 # command : target lat/lon

--- a/frl_vehicle_msgs/msg/UwGliderCommand.msg
+++ b/frl_vehicle_msgs/msg/UwGliderCommand.msg
@@ -7,11 +7,17 @@
 # header.stamp specifies the ROS time for this measurement 
 Header header
 
-# Command: target pitch angle in radians. Positive pitch is nose down, following REP-103.
-float32 target_pitch
+# Pitch control mode. Constants used as enum.
+uint8 pitch_cmd_type
+uint8 PITCH_CMD_BATT_POS=0
+uint8 PITCH_CMD_TARGET_ONCE=1
+uint8 PITCH_CMD_TARGET_SERVO=2
 
-# Command: target rate of descent/ascent in m/s.  Positive is up.
-float32 target_z_rate
+# Command: the desired pitch value
+# If pitch_cmd_type==PITCH_CMD_BATT_POS, specifies the position of the battery pack in m.
+# If pitch_cmd_type==PITCH_CMD_TARGET_ONCE, specifies the desired pitch angle in radians. Positive pitch is nose down. A table lookup is used to compute the desired battery position and no corrections are made.
+# If pitch_cmd_type==PITCH_CMD_TARGET_SERVO, specifies the desired pitch angle in radians. Positive pitch is nose down. The battery position is constantly servoed to maintain the target pitch.
+float32 target_pitch_value
 
 # Constants as an enum for modes of thrust input
 uint8 motor_cmd_type
@@ -45,11 +51,8 @@ uint8 RUDDER_ANGLE_DIRECT=3
 # Only pertinent if rudder_angle==RUDDER_ANGLE_DIRECT
 float32 target_rudder_angle
 
-# Command: battery pack position
-float32 target_battery_position
-
-# Command: buoyancy engine ballast pump position
-float32 target_ballast_position
+# Command: buoyancy engine pumped volume in L. Positive goes up.
+float32 target_pumped_volume
 
 # command : target lat/lon
 # float32 target_lat


### PR DESCRIPTION
Several fields were redundant with each other in the command. Fix by making the
command interface more similar to real hardware.

The glider's pitch angle is affected primarily by the battery pack
position. The glider lets us control the pitch in one of four ways:

1. (`PITCH_CMD_BATT_POS`) Setting the battery pack position directly.
2. (`PITCH_CMD_TARGET_ONCE`) Setting the target pitch angle and telling the
   glider to use an internal lookup table once to determine the desired battery
   pack position. This is the less power hungry "good enough" approach.
3. (`PITCH_CMD_TARGET_SERVO`) Setting the target pitch angle and telling the
   glider to constantly servo the battery pack to stay at the target. This is
   more energy intensive than the previous setting.
4. Using only the buoyancy engine. I didn't implement this in the message as
   we've never used it and I don't believe it gets you much pitch control at
   all.

The glider's dive/climb rate is affected by both the thruster and buoyancy
engine. The glider hardware lets us set either the desired pumped volume (what
this PR implements) or a desired speed. However, we've never used the desired
speed option and it's not immediately apparent how it interacts with the
thruster. If we want it, though, I can try to figure out how it works and
implement it in the Command message as well.