### PR TITLE
Non-zero option values

### DIFF
--- a/frl_vehicle_msgs/msg/UwGliderCommand.msg
+++ b/frl_vehicle_msgs/msg/UwGliderCommand.msg
@@ -9,9 +9,9 @@ Header header
 
 # Pitch control mode. Constants used as enum.
 uint8 pitch_cmd_type
-uint8 PITCH_CMD_BATT_POS=0
-uint8 PITCH_CMD_TARGET_ONCE=1
-uint8 PITCH_CMD_TARGET_SERVO=2
+uint8 PITCH_CMD_BATT_POS=1
+uint8 PITCH_CMD_TARGET_ONCE=2
+uint8 PITCH_CMD_TARGET_SERVO=3
 
 # Command: the desired pitch value
 # If pitch_cmd_type==PITCH_CMD_BATT_POS, specifies the position of the battery pack in m.
@@ -21,8 +21,8 @@ float32 target_pitch_value
 
 # Constants as an enum for modes of thrust input
 uint8 motor_cmd_type
-uint8 MOTOR_CMD_VOLTAGE=0
-uint8 MOTOR_CMD_POWER=1
+uint8 MOTOR_CMD_VOLTAGE=1
+uint8 MOTOR_CMD_POWER=2
 
 # Command: motor/thruster
 # If motor_cmd_type==MOTOR_CMD_VOLTAGE, expect range [0-100]
@@ -31,8 +31,8 @@ uint32 target_motor_cmd
 
 # Yaw control mode.  Constants used as enum.
 uint8 rudder_control_mode
-uint8 RUDDER_CONTROL_HEADING=0
-uint8 RUDDER_CONTROL_ANGLE=1
+uint8 RUDDER_CONTROL_HEADING=1
+uint8 RUDDER_CONTROL_ANGLE=2
 
 # Command: target heading in degrees NED
 # Only pertinent if rudder_control_mode==RUDDER_CONTROL_HEADING
@@ -42,10 +42,10 @@ float32 target_heading
 # Command: target rudder angle either centered, full port or full stbd
 # Only pertinent if rudder_control_mode==RUDDER_CONTROL_ANGLE
 uint8 rudder_angle
-uint8 RUDDER_ANGLE_CENTER=0
-uint8 RUDDER_ANGLE_PORT=1
-uint8 RUDDER_ANGLE_STBD=2
-uint8 RUDDER_ANGLE_DIRECT=3
+uint8 RUDDER_ANGLE_CENTER=1
+uint8 RUDDER_ANGLE_PORT=2
+uint8 RUDDER_ANGLE_STBD=3
+uint8 RUDDER_ANGLE_DIRECT=4
 
 # Command: target rudder angle in radians. Positive turns to starboard.
 # Only pertinent if rudder_angle==RUDDER_ANGLE_DIRECT

--- a/frl_vehicle_msgs/msg/UwGliderCommand.msg
+++ b/frl_vehicle_msgs/msg/UwGliderCommand.msg
@@ -9,11 +9,13 @@ Header header
 
 # Pitch control mode. Constants used as enum.
 uint8 pitch_cmd_type
+uint8 PITCH_CMD_NONE=0
 uint8 PITCH_CMD_BATT_POS=1
 uint8 PITCH_CMD_TARGET_ONCE=2
 uint8 PITCH_CMD_TARGET_SERVO=3
 
 # Command: the desired pitch value
+# If pitch_cmd_type==PITCH_CMD_NONE, leave pitch as it is
 # If pitch_cmd_type==PITCH_CMD_BATT_POS, specifies the position of the battery pack in m.
 # If pitch_cmd_type==PITCH_CMD_TARGET_ONCE, specifies the desired pitch angle in radians. Positive pitch is nose down. A table lookup is used to compute the desired battery position and no corrections are made.
 # If pitch_cmd_type==PITCH_CMD_TARGET_SERVO, specifies the desired pitch angle in radians. Positive pitch is nose down. The battery position is constantly servoed to maintain the target pitch.
@@ -21,16 +23,19 @@ float32 target_pitch_value
 
 # Constants as an enum for modes of thrust input
 uint8 motor_cmd_type
+uint8 MOTOR_CMD_NONE=0
 uint8 MOTOR_CMD_VOLTAGE=1
 uint8 MOTOR_CMD_POWER=2
 
 # Command: motor/thruster
+# If motor_cmd_type==MOTOR_CMD_NONE, leave motor/thrust as it is
 # If motor_cmd_type==MOTOR_CMD_VOLTAGE, expect range [0-100]
 # If motor_cmd_type==MOTOR_CMD_POWER, expect range [1-9]
 uint32 target_motor_cmd
 
 # Yaw control mode.  Constants used as enum.
 uint8 rudder_control_mode
+uint8 RUDDER_CONTROL_NONE=0
 uint8 RUDDER_CONTROL_HEADING=1
 uint8 RUDDER_CONTROL_ANGLE=2
 


### PR DESCRIPTION
It seems that the default values for custom msgs are zeros. It seems tricky to consider detecting what commands are conveyed. Especially the heading control in the world frame (rudder_control_mode == 0, head zero position values actually mean someplace). 

When we are controlling only pitch or only thruster, I would like to consider zero value as the command not being called. 

e.g.
Pitch control only : pitch_cmd_type = 1 or 2 / motor_cmd_type = 0
motor control only : pitch_cmd_type = 0 / motor_cmd_type = 1 or 2